### PR TITLE
Issue Save RSS (Data layer)

### DIFF
--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/SourceRssDataRepository.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/SourceRssDataRepository.kt
@@ -1,0 +1,10 @@
+package com.dherranz1.rss_aggregator.data
+
+import com.dherranz1.rss_aggregator.data.local.LocalDataSource
+import com.dherranz1.rss_aggregator.domain.SourceRssRepository
+
+class SourceRssDataRepository(private val localDataSource : LocalDataSource) : SourceRssRepository {
+    override fun create(name: String, url: String) {
+        localDataSource.save(name,url)
+    }
+}

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/local/LocalDataSource.kt
@@ -1,0 +1,5 @@
+package com.dherranz1.rss_aggregator.data.local
+
+interface LocalDataSource {
+    fun save(name : String, url : String)
+}

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/local/xml/XmlLocalDataSource.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/local/xml/XmlLocalDataSource.kt
@@ -1,0 +1,13 @@
+package com.dherranz1.rss_aggregator.data.local.xml
+
+import android.content.SharedPreferences
+import com.dherranz1.rss_aggregator.data.local.LocalDataSource
+
+class XmlLocalDataSource(private val sharedPreferences: SharedPreferences) : LocalDataSource {
+
+    val editor = sharedPreferences.edit()
+
+    override fun save(name: String, url: String) {
+        editor.putString(url,name).apply()
+    }
+}


### PR DESCRIPTION
## Description de la tarea

Implementación de la funcionalidad de guardado de los rrss, almacenando su nombre y dirección web.

## ¿Cómo se ha implementado?

Para abordar esta funcionalidad se tienen en cuenta el resto de opciones de guardado empleadas hasta ahora, concluyendo que usar el sharedpreferences es el método de guardado persistente más ligero. Guardar el nombre y la dirección es una tarea muy simple y emplear Room, u otros sevicios similares, implicaría consumir más recursos de forma innecesaria para únicamente guardar dos datos.

Para mantener la simplicidad y optimizar, se decide guardar directamente la url como clave y como valor el nombre del rss. De este modo se obtiene una clave que va a ser única y se evita el uso de serializadores.

Se crea:

- La interfaz LocalDataSource.
- SourceRssDataRepository, que es la clase que implementa la interfaz del dominio y usa la interfaz LocalDataSource para guardar los datos en local.
- XmlLocalDataSource que implementa la interfaz LocalDataSource, guardando los datos en el fichero xml de sharedpreferences.

## Keywords

- Data Repository
- Local data source
- Sharedpreferences

## Screenshots or Video

![issue3data](https://user-images.githubusercontent.com/114154511/202429886-c563f98f-a383-4e92-8335-e318ee416f1e.png)


## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->