### PR TITLE
Issue 10, added new feature get rss sources in data layer

### DIFF
--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/SourceRssDataRepository.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/SourceRssDataRepository.kt
@@ -1,10 +1,14 @@
 package com.dherranz1.rss_aggregator.data
 
 import com.dherranz1.rss_aggregator.data.local.LocalDataSource
+import com.dherranz1.rss_aggregator.domain.SourceRss
 import com.dherranz1.rss_aggregator.domain.SourceRssRepository
 
 class SourceRssDataRepository(private val localDataSource : LocalDataSource) : SourceRssRepository {
     override fun create(name: String, url: String) {
         localDataSource.save(name,url)
     }
+
+    override fun getAllSources(): List<SourceRss> =
+        localDataSource.getAllSources()
 }

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/local/LocalDataSource.kt
@@ -1,5 +1,8 @@
 package com.dherranz1.rss_aggregator.data.local
 
+import com.dherranz1.rss_aggregator.domain.SourceRss
+
 interface LocalDataSource {
     fun save(name : String, url : String)
+    fun getAllSources() : List<SourceRss>
 }

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/local/xml/XmlLocalDataSource.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/local/xml/XmlLocalDataSource.kt
@@ -2,12 +2,21 @@ package com.dherranz1.rss_aggregator.data.local.xml
 
 import android.content.SharedPreferences
 import com.dherranz1.rss_aggregator.data.local.LocalDataSource
+import com.dherranz1.rss_aggregator.domain.SourceRss
 
 class XmlLocalDataSource(private val sharedPreferences: SharedPreferences) : LocalDataSource {
 
-    val editor = sharedPreferences.edit()
+    private val editor = sharedPreferences.edit()
 
     override fun save(name: String, url: String) {
         editor.putString(url,name).apply()
     }
+
+    override fun getAllSources(): List<SourceRss> =
+        sharedPreferences.all.map { rss ->
+            SourceRss(
+                name = rss.value.toString(),
+                url = rss.key.toString()
+            )
+        }
 }


### PR DESCRIPTION
## Description de la tarea

Recuperar el listado de fuentes Rss que ha introducido el usuario de la fuente de datos xml.

## ¿Cómo se ha implementado?

- Se añade el método getAllSources a la clase SourceRssDataRepository, que implementa la interfaz repositorio del dominio.
- También se agrega el mismo método a la interfaz LocalDataSource
- XmlLocalDataSource implementa el método getAllSources, devolviendo en todo caso una lista, con elementos del modelo de dominio SourceRss o vacía en caso de no haber ninguno. 

## Keywords

- SharedPreferences
- Local Data Source
- Data layer
- Repository

## Screenshots or Video

A continuación se comprueba el correcto funcionamiento y recuperación de los datos

![prGetRssData](https://user-images.githubusercontent.com/114154511/202846921-fb11c431-878c-401c-9c64-8d576c6bb583.png)


## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->