### PR TITLE
Issue 9, Delete rss source use case (Domain)

### DIFF
--- a/app/src/main/java/com/dherranz1/rss_aggregator/domain/DeleteSourceRssUseCase.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/domain/DeleteSourceRssUseCase.kt
@@ -1,0 +1,13 @@
+package com.dherranz1.rss_aggregator.domain
+
+class DeleteSourceRssUseCase(private val repository: SourceRssRepository) {
+    fun execute(id : String) : Either<ErrorApp,String>{
+        val result = repository.delete(id)
+
+        return if (result.isLeft())
+            ErrorApp.DataError().left()
+        else{
+            result.get().right()
+        }
+    }
+}

--- a/app/src/main/java/com/dherranz1/rss_aggregator/domain/SourceRssRepository.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/domain/SourceRssRepository.kt
@@ -3,4 +3,5 @@ package com.dherranz1.rss_aggregator.domain
 interface SourceRssRepository {
     fun create(name : String, url : String)
     fun getAllSources() : List<SourceRss>
+    fun delete(id : String) : Either<ErrorApp,String>
 }


### PR DESCRIPTION
## Description de la tarea

Implementar un caso de uso que permita eliminar una fuente de RSS introducida por el usuario. El caso de uso deberá devolver el resultado de la operación: error o success.

## ¿Cómo se ha implementado?

- Se incorpora Either para la gestión de la respuesta.
- Se agrega el método delete a la interfaz de repositorio del dominio.
- Creación de la clase DeleteSourceRssUseCase que usa la interfaz del repositorio para eliminar una fuente de rss

## Keywords

- Either
- Domain layer
- Use case
- Delete

## Screenshots or Video

<!-- Captura de pantalla de la consola -->

## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->