### PR TITLE
Issue2 - Implementar cliente api xml

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,16 @@ android {
 
 dependencies {
 
+    //Simple XML
+    implementation group: 'org.simpleframework', name: 'simple-xml', version: '2.7'
+
+    // Retrofit
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-simplexml:2.9.0'
+
+    // Coroutines
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.7.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/ApiClient.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/ApiClient.kt
@@ -1,0 +1,15 @@
+package com.dherranz1.rss_aggregator.data.remote.retrofit
+
+import retrofit2.Retrofit
+import retrofit2.converter.simplexml.SimpleXmlConverterFactory
+
+class ApiClient(private val urlweb : String) {
+    val baseUrl : String = urlweb
+    
+    private val retrofit : Retrofit = Retrofit.Builder()
+        .baseUrl("https://google.es/")
+        .addConverterFactory(SimpleXmlConverterFactory.create())
+        .build()
+
+    fun getInstance() = retrofit
+}

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/ApiModels.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/ApiModels.kt
@@ -1,0 +1,57 @@
+package com.dherranz1.rss_aggregator.data.remote.retrofit
+
+import org.simpleframework.xml.*
+
+@Root(name = "rss", strict = false)
+data class RssApiModel @JvmOverloads constructor(
+
+    @field:Attribute(name = "version")
+    var version: String? = null,
+
+    @field:Element(name="channel", required = false)
+    var channel: ChannelApiModel = ChannelApiModel()
+
+)
+
+@Root(name = "channel", strict = false)
+data class ChannelApiModel @JvmOverloads constructor(
+
+    @field:Path("title")
+    @field:Text(required = false)
+    var title: String? = null,
+
+    @field:Path("link")
+    @field:Text(required = false)
+    var link: String? = null,
+
+    @field:Path("pubDate")
+    @field:Text(required = false)
+    var pubDate: String? = null,
+
+    @field:Path("description")
+    @field:Text(required = false)
+    var description: String? = null,
+
+    @field:ElementList(name = "item", inline = true, required = false)
+    var itemList: List<ItemApiModel>? = null
+)
+
+@Root(name = "item", strict = false)
+data class ItemApiModel @JvmOverloads constructor(
+
+    @field:Path("title")
+    @field:Text(required = false)
+    var title: String? = null,
+
+    @field:Path("description")
+    @field:Text(required = false)
+    var description: String? = null,
+
+    @field:Path("link")
+    @field:Text(required = false)
+    var link: String? = null,
+
+    @field:Path("media:thumbnail")
+    @field:Attribute(name = "url", required = false)
+    var linkmedia: String? = null
+)

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/RssRemoteDataSource.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/RssRemoteDataSource.kt
@@ -1,0 +1,13 @@
+package com.dherranz1.rss_aggregator.data.remote.retrofit
+
+
+class RssRemoteDataSource(private val apiClient : ApiClient)  {
+
+    private var service: RssService = apiClient.getInstance().create(RssService::class.java)
+
+    suspend fun getAll(): RssApiModel? {
+        return service.getAll(apiClient.baseUrl).body()
+    }
+
+
+}

--- a/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/RssService.kt
+++ b/app/src/main/java/com/dherranz1/rss_aggregator/data/remote/retrofit/RssService.kt
@@ -1,0 +1,12 @@
+package com.dherranz1.rss_aggregator.data.remote.retrofit
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+
+interface RssService {
+
+    @GET
+    suspend fun getAll(@Url url:String): Response<RssApiModel?>
+}


### PR DESCRIPTION
## Description de la tarea

Se pide implementar un cliente API capaz de parsear la información RSS (Xml)

## ¿Cómo se ha implementado?

- Se agrega Retrofit y permisos de internet
- Se agrega Simple XML
- Creación de los modelos de datos de api que recogen la información de la respuesta xml
- Definición de la interaz RssService que usará retrofit 
- ApiClient nos devuelve una instancia de retrofit con la que poder trabajar con los métodos
- RssRemoteDataSource hace uso del cliente api para llamar a los métodos definidos en la interfaz de retrofit

## Keywords

- Simple XML
- API
- Retrofit
- Remote data source

## Screenshots or Video

![prRetrofit](https://user-images.githubusercontent.com/114154511/203551190-9096893c-c318-4ecb-909e-cb055f2a5e7a.png)


## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->